### PR TITLE
feat(init): init namespace configurations

### DIFF
--- a/steps/init/init.yaml
+++ b/steps/init/init.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limit-range
+spec:
+  limits:
+    - default:
+        cpu: 1
+        memory: 500Mi
+      defaultRequest:
+        cpu: 0.5
+        memory: 200Mi
+      type: Container


### PR DESCRIPTION
To test with a deployment in a custom namespace which miss the request resources section